### PR TITLE
PowerToys Run for 0.75.1 requires Plugin ID in Main

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -44,6 +44,8 @@ namespace Community.PowerToys.Run.Plugin.Winget
 
         public string Description => Properties.Resources.plugin_description;
 
+        public static string PluginID => "46778CB7A2FD4949A845B19EF1A6364B";
+
         public IEnumerable<PluginAdditionalOption> AdditionalOptions => new List<PluginAdditionalOption>()
         {
             new PluginAdditionalOption()


### PR DESCRIPTION
Fix for #18 caused by https://github.com/microsoft/PowerToys/pull/27468 for reason: "On plugin init each plugin's id will be compared against a property in plugins code. We do this as protection against plugin.json manipulations. (⚠️ This is be a braking change!!)"

