### PR TITLE
Fix PowerToys Run Plugin Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a plugin for [PowerToys Run](https://github.com/microsoft/PowerToys/wiki
 ## Installation
 
 1. Download the latest release of the Winget Plugin from the [releases page](https://github.com/bostrot/PowerToysRunPluginWinget/releases).
-2. Extract the zip file's contents to your PowerToys modules directory (usually `%LOCALAPPDATA%\Microsoft\PowerToys\RunPlugins`).
+2. Extract the zip file's contents to your PowerToys modules directory (usually `%LOCALAPPDATA%\Microsoft\PowerToys Run\Plugins`).
 3. Restart PowerToys.
 
 ## Usage


### PR DESCRIPTION
I'm unsure if the `PATH` the `Docs`  in older versions but as of PowerToys `v0.79.0` this seems to be the valid `PATH`
`%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins` seems to be the valid PowerToys Run `PATH`